### PR TITLE
Add line breaks for function arguments

### DIFF
--- a/files/LASA IntelliJ IDEA CPP Code Style.xml
+++ b/files/LASA IntelliJ IDEA CPP Code Style.xml
@@ -1,11 +1,14 @@
-<code_scheme name="LASA Style" version="2">
+<code_scheme name="LASA Style" version="3">
   <Objective-C>
     <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
     <option name="INDENT_C_STRUCT_MEMBERS" value="2" />
     <option name="INDENT_CLASS_MEMBERS" value="2" />
     <option name="INDENT_INSIDE_CODE_BLOCK" value="2" />
-    <option name="FUNCTION_PARAMETERS_WRAP" value="5" />
-    <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5" />
+    <option name="FUNCTION_PARAMETERS_NEW_LINE_AFTER_LPAR" value="true" />
+    <option name="FUNCTION_PARAMETERS_NEW_LINE_BEFORE_RPAR" value="true" />
+    <option name="LAMBDA_CAPTURE_LIST_WRAP" value="5" />
+    <option name="FUNCTION_CALL_ARGUMENTS_NEW_LINE_AFTER_LPAR" value="true" />
+    <option name="FUNCTION_CALL_ARGUMENTS_NEW_LINE_BEFORE_RPAR" value="true" />
     <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5" />
     <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true" />
     <option name="CLASS_CONSTRUCTOR_INIT_LIST_WRAP" value="5" />
@@ -18,6 +21,7 @@
     <option name="SPACE_BEFORE_REFERENCE_IN_DECLARATION" value="false" />
     <option name="SPACE_AFTER_REFERENCE_IN_DECLARATION" value="true" />
     <option name="KEEP_BLANK_LINES_BEFORE_END" value="1" />
+    <option name="ADD_BRIEF_TAG" value="true" />
     <option name="HEADER_GUARD_STYLE_PATTERN" value="${PROJECT_NAME}_${PROJECT_REL_PATH}_${FILE_NAME}_${EXT}_" />
   </Objective-C>
   <Objective-C-extensions>


### PR DESCRIPTION
* Revise IntelliJ code style to wrap function arguments
if long, with a new line after ( and before ), and
aligning arguments at the continuation indent rather
than the end of the function.

This always moves arguments back to near the function
level, which helps to avoid massive indent blocks when
the line before the arguments themselves are long.

This example function:

```
void foo(int a, int b, int c) {
  //
}
```

was previously wrapped to:
```
void foo(int a,
         int b,
         int c) {

}
```

Now it becomes:
```
void foo(
    int a, int b,
    int c
) {
  //
}
```

---

Here's a concrete example

Before
```c++
client_change_state_->async_send_request(request,
                                         [this, transition](rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedFuture future) {
                                           auto response = future.get();
                                           if (response->success) {
                                             RCLCPP_INFO(parent_->get_logger(),
                                                         "Transition %i successfully triggered on component %s",
                                                         static_cast<int>(transition),
                                                         this->remote_node_name_.c_str());
                                           } else {
                                             RCLCPP_ERROR(parent_->get_logger(),
                                                          "Failed to trigger transition %i on component %s",
                                                          static_cast<unsigned int>(transition),
                                                          this->remote_node_name_.c_str());
                                           }
                                         });
```

After
```c++
client_change_state_->async_send_request(
    request, [this, transition](rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedFuture future) {
      auto response = future.get();
      if (response->success) {
        RCLCPP_INFO(parent_->get_logger(), "Transition %i successfully triggered on component %s",
            static_cast<int>(transition), this->remote_node_name_.c_str()
        );
      } else {
        RCLCPP_ERROR(parent_->get_logger(), "Failed to trigger transition %i on component %s",
            static_cast<unsigned int>(transition), this->remote_node_name_.c_str()
        );
      }
    }
);
```